### PR TITLE
Add the 'ARCH' variable to morty.sh

### DIFF
--- a/utils/morty.sh
+++ b/utils/morty.sh
@@ -34,7 +34,7 @@ SERVICE_GROUP="${SERVICE_USER}"
 SERVICE_ENV_DEBUG=false
 
 GO_ENV="${SERVICE_HOME}/.go_env"
-GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz"
+GO_PKG_URL="https://dl.google.com/go/go1.13.5.linux-$ARCH.tar.gz"
 GO_TAR=$(basename "$GO_PKG_URL")
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
I add the 'ARCH' variable to morty.sh as part of the ARM64 support project.

## What does this PR do?

<!-- MANDATORY -->

<!-- explain the changes in your PR, algorithms, design, architecture -->

## Why is this change important?

<!-- MANDATORY -->

<!-- explain the motivation behind your PR -->

## How to test this PR locally?

<!-- commands to run the tests or instructions to test the changes-->

## Author's checklist

<!-- additional notes for reviewiers -->

## Related issues

<!--
Closes #234
-->
